### PR TITLE
fix: handle printJSON error in upCmd, matching downCmd pattern

### DIFF
--- a/cmd/aurelia/client.go
+++ b/cmd/aurelia/client.go
@@ -153,17 +153,26 @@ var upCmd = &cobra.Command{
 			return nil
 		}
 
+		var results []map[string]any
 		for _, name := range args {
 			result, err := apiPost(fmt.Sprintf("/v1/services/%s/start", name))
 			if err != nil {
-				fmt.Fprintf(os.Stderr, "%s: %v\n", name, err)
+				if jsonOut {
+					results = append(results, map[string]any{"service": name, "error": err.Error()})
+				} else {
+					fmt.Fprintf(os.Stderr, "%s: %v\n", name, err)
+				}
 				continue
 			}
 			if jsonOut {
-				printJSON(result)
+				result["service"] = name
+				results = append(results, result)
 			} else {
 				fmt.Printf("%s: %v\n", name, result["status"])
 			}
+		}
+		if jsonOut {
+			return printJSON(results)
 		}
 		return nil
 	},


### PR DESCRIPTION
The upCmd was calling printJSON(result) inside a loop without handling
the returned error. This aligns with the downCmd pattern: collect results
into a slice and call printJSON once at the end. Also surfaces errors
in JSON mode for consistency.

https://claude.ai/code/session_01DVXyWYQR4EyRKMA31PAwEG