### PR TITLE
fix: guard debounce callback against context cancellation

### DIFF
--- a/internal/daemon/watcher.go
+++ b/internal/daemon/watcher.go
@@ -49,6 +49,9 @@ func (d *Daemon) StartWatcher(ctx context.Context) error {
 				debounceTimer.Stop()
 			}
 			debounceTimer = time.AfterFunc(watcherDebounce, func() {
+				if ctx.Err() != nil {
+					return // context already cancelled, skip reload
+				}
 				d.logger.Info("reloading specs after file change")
 				result, err := d.Reload(ctx)
 				if err != nil {


### PR DESCRIPTION
## Summary

- Adds a `ctx.Err()` check at the start of the `time.AfterFunc` callback in `StartWatcher` to skip `Reload()` when the context is already cancelled
- The existing `debounceTimer.Stop()` in the `ctx.Done()` case handles most scenarios, but a race exists where the timer fires between scheduling and `Stop()` — this guards against that window
- Prevents unnecessary work and error log spam on shutdown

Fixes #33

## Test plan

- [x] `go build ./...` compiles cleanly
- [x] `go test ./internal/daemon/...` passes
- [ ] Manual: start daemon with watcher, trigger a file change, then immediately cancel context — verify no "auto-reload failed" error in logs