### PR TITLE
feat: warn on sensitive container volume mounts in aurelia check

### DIFF
--- a/cmd/aurelia/check.go
+++ b/cmd/aurelia/check.go
@@ -10,11 +10,12 @@ import (
 )
 
 type checkResult struct {
-	Path  string `json:"path"`
-	Name  string `json:"name,omitempty"`
-	Type  string `json:"type,omitempty"`
-	Valid bool   `json:"valid"`
-	Error string `json:"error,omitempty"`
+	Path     string   `json:"path"`
+	Name     string   `json:"name,omitempty"`
+	Type     string   `json:"type,omitempty"`
+	Valid    bool     `json:"valid"`
+	Error    string   `json:"error,omitempty"`
+	Warnings []string `json:"warnings,omitempty"`
 }
 
 var checkCmd = &cobra.Command{
@@ -62,7 +63,9 @@ func runCheck(cmd *cobra.Command, args []string) error {
 			results = append(results, checkResult{Path: path, Valid: false, Error: err.Error()})
 			failed++
 		} else {
-			results = append(results, checkResult{Path: path, Name: s.Service.Name, Type: string(s.Service.Type), Valid: true})
+			r := checkResult{Path: path, Name: s.Service.Name, Type: string(s.Service.Type), Valid: true}
+			r.Warnings = s.Warnings()
+			results = append(results, r)
 		}
 	}
 
@@ -74,6 +77,9 @@ func runCheck(cmd *cobra.Command, args []string) error {
 	for _, r := range results {
 		if r.Valid {
 			fmt.Printf("OK    %s (%s, %s)\n", r.Path, r.Name, r.Type)
+			for _, w := range r.Warnings {
+				fmt.Fprintf(os.Stderr, "WARN  %s: %s\n", r.Path, w)
+			}
 		} else {
 			fmt.Fprintf(os.Stderr, "FAIL  %s\n      %v\n", r.Path, r.Error)
 		}

--- a/internal/spec/spec.go
+++ b/internal/spec/spec.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"strings"
 	"time"
 
 	"gopkg.in/yaml.v3"
@@ -315,4 +316,43 @@ func (s *ServiceSpec) Validate() error {
 	}
 
 	return nil
+}
+
+// sensitivePaths lists host paths that are security-sensitive when mounted
+// into containers. Each entry has a path pattern and a human-readable reason.
+var sensitivePaths = []struct {
+	path   string
+	reason string
+}{
+	{"/etc/shadow", "password hashes"},
+	{"/etc/passwd", "user account info"},
+	{"/etc/master.passwd", "password hashes (BSD)"},
+	{"/.ssh", "SSH private keys"},
+	{"/.gnupg", "GPG private keys"},
+	{"/var/run/docker.sock", "Docker daemon access"},
+	{"/run/docker.sock", "Docker daemon access"},
+}
+
+// Warnings returns advisory warnings about the spec. These do not prevent
+// the spec from loading but highlight potentially risky configurations.
+func (s *ServiceSpec) Warnings() []string {
+	var warnings []string
+
+	for hostPath := range s.Volumes {
+		// Exact root mount
+		if hostPath == "/" {
+			warnings = append(warnings, "volume mounts host root filesystem (/)")
+			continue
+		}
+
+		clean := filepath.Clean(hostPath)
+		for _, sp := range sensitivePaths {
+			if clean == sp.path || strings.HasSuffix(clean, sp.path) {
+				warnings = append(warnings, fmt.Sprintf("volume mounts sensitive path %s (%s)", hostPath, sp.reason))
+				break
+			}
+		}
+	}
+
+	return warnings
 }

--- a/internal/spec/spec_test.go
+++ b/internal/spec/spec_test.go
@@ -3,6 +3,7 @@ package spec
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -865,6 +866,90 @@ env:
 	}
 	if spec.Env["DATA_DIR"] != "/opt/aurelia/data" {
 		t.Errorf("Env[DATA_DIR] = %q, want expanded path", spec.Env["DATA_DIR"])
+	}
+}
+
+func TestWarningsSensitiveVolumeMounts(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		volumes  map[string]string
+		wantWarn int
+		contains string
+	}{
+		{
+			name:     "docker socket",
+			volumes:  map[string]string{"/var/run/docker.sock": "/var/run/docker.sock"},
+			wantWarn: 1,
+			contains: "Docker daemon access",
+		},
+		{
+			name:     "etc shadow",
+			volumes:  map[string]string{"/etc/shadow": "/mnt/shadow"},
+			wantWarn: 1,
+			contains: "password hashes",
+		},
+		{
+			name:     "ssh directory",
+			volumes:  map[string]string{"/home/user/.ssh": "/root/.ssh"},
+			wantWarn: 1,
+			contains: "SSH private keys",
+		},
+		{
+			name:     "gnupg directory",
+			volumes:  map[string]string{"/home/user/.gnupg": "/root/.gnupg"},
+			wantWarn: 1,
+			contains: "GPG private keys",
+		},
+		{
+			name:     "root mount",
+			volumes:  map[string]string{"/": "/host"},
+			wantWarn: 1,
+			contains: "root filesystem",
+		},
+		{
+			name:     "safe volume no warning",
+			volumes:  map[string]string{"/data": "/app/data"},
+			wantWarn: 0,
+		},
+		{
+			name:     "no volumes no warning",
+			volumes:  nil,
+			wantWarn: 0,
+		},
+		{
+			name:     "etc passwd",
+			volumes:  map[string]string{"/etc/passwd": "/mnt/passwd"},
+			wantWarn: 1,
+			contains: "user account info",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			s := &ServiceSpec{
+				Service: Service{Name: "test", Type: "container", Image: "nginx"},
+				Volumes: tt.volumes,
+			}
+			warnings := s.Warnings()
+			if len(warnings) != tt.wantWarn {
+				t.Errorf("expected %d warnings, got %d: %v", tt.wantWarn, len(warnings), warnings)
+			}
+			if tt.contains != "" && len(warnings) > 0 {
+				found := false
+				for _, w := range warnings {
+					if strings.Contains(w, tt.contains) {
+						found = true
+						break
+					}
+				}
+				if !found {
+					t.Errorf("expected warning containing %q, got %v", tt.contains, warnings)
+				}
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## Summary

- Add `Warnings()` method to `ServiceSpec` that detects security-sensitive host paths in volume mounts (Docker socket, SSH keys, `/etc/shadow`, `/etc/passwd`, GPG keys, root filesystem)
- Warnings are advisory only — they do not block spec validation or loading
- Update `aurelia check` to display warnings in both human-readable (`WARN` prefix to stderr) and JSON output (`warnings` field)

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./...` passes
- [x] New `TestWarningsSensitiveVolumeMounts` covers all sensitive path patterns and safe paths

Closes #36