### PR TITLE
feat: support env var interpolation in service specs

### DIFF
--- a/internal/daemon/service.go
+++ b/internal/daemon/service.go
@@ -523,7 +523,17 @@ func (ms *ManagedService) buildEnvWithPort(port int) []string {
 		env = append(env, fmt.Sprintf("PORT=%d", port))
 	}
 
-	for k, v := range ms.spec.Env {
+	// Build runtime variables for interpolation within env values.
+	// This allows specs like: SERVER_PORT: "${PORT}"
+	runtimeVars := map[string]string{
+		"SERVICE_NAME": ms.spec.Service.Name,
+	}
+	if port != 0 {
+		runtimeVars["PORT"] = fmt.Sprintf("%d", port)
+	}
+
+	interpolatedEnv := spec.InterpolateRuntimeVars(ms.spec.Env, runtimeVars)
+	for k, v := range interpolatedEnv {
 		env = append(env, k+"="+v)
 	}
 

--- a/internal/daemon/service_test.go
+++ b/internal/daemon/service_test.go
@@ -457,6 +457,101 @@ func TestManagedServiceSecretInjection(t *testing.T) {
 	}
 }
 
+func TestManagedServiceEnvVarInterpolation(t *testing.T) {
+	s := &spec.ServiceSpec{
+		Service: spec.Service{
+			Name:    "test-interpolation",
+			Type:    "native",
+			Command: "printenv SERVER_PORT",
+		},
+		Network: &spec.Network{Port: 9090},
+		Env: map[string]string{
+			"SERVER_PORT": "${PORT}",
+		},
+		Restart: &spec.RestartPolicy{
+			Policy: "never",
+		},
+	}
+
+	ms, err := NewManagedService(s, nil)
+	if err != nil {
+		t.Fatalf("failed to create: %v", err)
+	}
+
+	ctx := context.Background()
+	if err := ms.Start(ctx); err != nil {
+		t.Fatalf("failed to start: %v", err)
+	}
+
+	waitUntil(t, func() bool {
+		if ms.drv == nil {
+			return false
+		}
+		return len(ms.drv.LogLines(1)) > 0
+	}, 2*time.Second, "process to produce log output")
+
+	ms.Stop(5 * time.Second)
+
+	lines := ms.drv.LogLines(10)
+	found := false
+	for _, line := range lines {
+		if strings.TrimSpace(line) == "9090" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("expected SERVER_PORT=9090 (interpolated from PORT), log output: %v", lines)
+	}
+}
+
+func TestManagedServiceEnvVarServiceName(t *testing.T) {
+	s := &spec.ServiceSpec{
+		Service: spec.Service{
+			Name:    "my-web-app",
+			Type:    "native",
+			Command: "printenv APP_NAME",
+		},
+		Env: map[string]string{
+			"APP_NAME": "${SERVICE_NAME}",
+		},
+		Restart: &spec.RestartPolicy{
+			Policy: "never",
+		},
+	}
+
+	ms, err := NewManagedService(s, nil)
+	if err != nil {
+		t.Fatalf("failed to create: %v", err)
+	}
+
+	ctx := context.Background()
+	if err := ms.Start(ctx); err != nil {
+		t.Fatalf("failed to start: %v", err)
+	}
+
+	waitUntil(t, func() bool {
+		if ms.drv == nil {
+			return false
+		}
+		return len(ms.drv.LogLines(1)) > 0
+	}, 2*time.Second, "process to produce log output")
+
+	ms.Stop(5 * time.Second)
+
+	lines := ms.drv.LogLines(10)
+	found := false
+	for _, line := range lines {
+		if strings.TrimSpace(line) == "my-web-app" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("expected APP_NAME=my-web-app (interpolated from SERVICE_NAME), log output: %v", lines)
+	}
+}
+
 func TestManagedServiceStopNotRunning(t *testing.T) {
 	s := &spec.ServiceSpec{
 		Service: spec.Service{

--- a/internal/spec/spec.go
+++ b/internal/spec/spec.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"strings"
 	"time"
 
 	"gopkg.in/yaml.v3"
@@ -117,6 +118,86 @@ func (s *ServiceSpec) ExpandEnv() {
 		}
 		s.Volumes = expanded
 	}
+}
+
+// InterpolateRuntimeVars performs variable interpolation on env values using
+// Aurelia-managed runtime variables (e.g. PORT, SERVICE_NAME). This supports
+// both ${VAR} and $VAR syntax within env block values, allowing specs like:
+//
+//	env:
+//	  SERVER_PORT: "${PORT}"
+//
+// Unlike ExpandEnv (which runs at load time against host env), this runs at
+// service start time when runtime variables like the allocated port are known.
+func InterpolateRuntimeVars(env map[string]string, runtimeVars map[string]string) map[string]string {
+	if len(env) == 0 || len(runtimeVars) == 0 {
+		return env
+	}
+	result := make(map[string]string, len(env))
+	for k, v := range env {
+		result[k] = expandRuntimeVars(v, runtimeVars)
+	}
+	return result
+}
+
+// expandRuntimeVars replaces ${VAR} and $VAR references in s with values from
+// vars. References to keys not in vars are left as literal text.
+func expandRuntimeVars(s string, vars map[string]string) string {
+	var b strings.Builder
+	b.Grow(len(s))
+
+	i := 0
+	for i < len(s) {
+		if s[i] != '$' || i+1 >= len(s) {
+			b.WriteByte(s[i])
+			i++
+			continue
+		}
+
+		// Peek ahead
+		j := i + 1
+		braced := false
+		if s[j] == '{' {
+			braced = true
+			j++
+		}
+
+		// Collect variable name (alphanumeric + underscore)
+		start := j
+		for j < len(s) && (s[j] == '_' || (s[j] >= 'a' && s[j] <= 'z') || (s[j] >= 'A' && s[j] <= 'Z') || (s[j] >= '0' && s[j] <= '9')) {
+			j++
+		}
+
+		name := s[start:j]
+
+		if braced {
+			if j < len(s) && s[j] == '}' {
+				j++ // consume closing brace
+			} else {
+				// Malformed ${...}, emit literally
+				b.WriteByte('$')
+				i++
+				continue
+			}
+		}
+
+		if name == "" {
+			// Bare $ or ${}, emit literally
+			b.WriteString(s[i:j])
+			i = j
+			continue
+		}
+
+		if val, ok := vars[name]; ok {
+			b.WriteString(val)
+		} else {
+			// Not a runtime var — preserve original text
+			b.WriteString(s[i:j])
+		}
+		i = j
+	}
+
+	return b.String()
 }
 
 // Load reads and parses a service spec from a YAML file.

--- a/internal/spec/spec_test.go
+++ b/internal/spec/spec_test.go
@@ -868,6 +868,107 @@ env:
 	}
 }
 
+func TestInterpolateRuntimeVars(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		env         map[string]string
+		runtimeVars map[string]string
+		want        map[string]string
+	}{
+		{
+			name:        "braced syntax",
+			env:         map[string]string{"SERVER_PORT": "${PORT}"},
+			runtimeVars: map[string]string{"PORT": "8080"},
+			want:        map[string]string{"SERVER_PORT": "8080"},
+		},
+		{
+			name:        "bare syntax",
+			env:         map[string]string{"SERVER_PORT": "$PORT"},
+			runtimeVars: map[string]string{"PORT": "8080"},
+			want:        map[string]string{"SERVER_PORT": "8080"},
+		},
+		{
+			name:        "embedded in string",
+			env:         map[string]string{"LISTEN_ADDR": "0.0.0.0:${PORT}"},
+			runtimeVars: map[string]string{"PORT": "9090"},
+			want:        map[string]string{"LISTEN_ADDR": "0.0.0.0:9090"},
+		},
+		{
+			name:        "multiple vars",
+			env:         map[string]string{"APP_URL": "http://${SERVICE_NAME}:${PORT}"},
+			runtimeVars: map[string]string{"PORT": "3000", "SERVICE_NAME": "web"},
+			want:        map[string]string{"APP_URL": "http://web:3000"},
+		},
+		{
+			name:        "unknown var preserved",
+			env:         map[string]string{"FOO": "${UNKNOWN_VAR}"},
+			runtimeVars: map[string]string{"PORT": "8080"},
+			want:        map[string]string{"FOO": "${UNKNOWN_VAR}"},
+		},
+		{
+			name:        "no interpolation needed",
+			env:         map[string]string{"STATIC": "hello"},
+			runtimeVars: map[string]string{"PORT": "8080"},
+			want:        map[string]string{"STATIC": "hello"},
+		},
+		{
+			name:        "nil env returns nil",
+			env:         nil,
+			runtimeVars: map[string]string{"PORT": "8080"},
+			want:        nil,
+		},
+		{
+			name:        "empty runtime vars returns original",
+			env:         map[string]string{"FOO": "${PORT}"},
+			runtimeVars: map[string]string{},
+			want:        map[string]string{"FOO": "${PORT}"},
+		},
+		{
+			name:        "service name interpolation",
+			env:         map[string]string{"APP_NAME": "${SERVICE_NAME}"},
+			runtimeVars: map[string]string{"SERVICE_NAME": "my-app"},
+			want:        map[string]string{"APP_NAME": "my-app"},
+		},
+		{
+			name:        "mixed known and unknown",
+			env:         map[string]string{"ADDR": "${HOST}:${PORT}"},
+			runtimeVars: map[string]string{"PORT": "8080"},
+			want:        map[string]string{"ADDR": "${HOST}:8080"},
+		},
+		{
+			name:        "bare dollar at end of string",
+			env:         map[string]string{"FOO": "price$"},
+			runtimeVars: map[string]string{"PORT": "8080"},
+			want:        map[string]string{"FOO": "price$"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := InterpolateRuntimeVars(tt.env, tt.runtimeVars)
+			if tt.want == nil {
+				if got != nil {
+					t.Errorf("expected nil, got %v", got)
+				}
+				return
+			}
+			if len(got) != len(tt.want) {
+				t.Errorf("length mismatch: got %d, want %d", len(got), len(tt.want))
+			}
+			for k, wantV := range tt.want {
+				if gotV, ok := got[k]; !ok {
+					t.Errorf("missing key %q", k)
+				} else if gotV != wantV {
+					t.Errorf("key %q: got %q, want %q", k, gotV, wantV)
+				}
+			}
+		})
+	}
+}
+
 func TestValidateContainerServiceAllowsArgs(t *testing.T) {
 	t.Parallel()
 	spec := &ServiceSpec{


### PR DESCRIPTION
## Summary

- Add `InterpolateRuntimeVars` to the spec package that performs `${VAR}` / `$VAR` substitution using Aurelia-managed runtime variables (currently `PORT` and `SERVICE_NAME`)
- Integrate into `buildEnvWithPort` in the daemon so interpolation happens at service start time, after port allocation
- Unknown variable references are preserved as literal text (not blanked), keeping behavior predictable

This lets users bridge Aurelia's port allocation to framework-specific env vars without code changes:

```yaml
env:
  SERVER_PORT: "${PORT}"
  APP_NAME: "${SERVICE_NAME}"
```

Fixes #39

## Test plan

- [x] Unit tests for `InterpolateRuntimeVars`: braced/bare syntax, embedded in strings, multiple vars, unknown vars preserved, nil/empty edge cases
- [x] Integration tests in daemon: `TestManagedServiceEnvVarInterpolation` (PORT -> SERVER_PORT) and `TestManagedServiceEnvVarServiceName` (SERVICE_NAME -> APP_NAME)
- [x] All existing tests pass (`go test ./...`)
- [x] `go vet ./...` clean