### PR TITLE
fix: add per-line byte limit to log ring buffer

### DIFF
--- a/internal/logbuf/ring.go
+++ b/internal/logbuf/ring.go
@@ -7,14 +7,19 @@ import (
 	"sync"
 )
 
+// DefaultMaxLineBytes is the default maximum size of a single log line in bytes.
+// Lines longer than this are truncated to prevent unbounded memory usage.
+const DefaultMaxLineBytes = 8192
+
 // Ring is a thread-safe ring buffer that stores the last N lines of output.
 // It implements io.Writer so it can be used as stdout/stderr for a process.
 type Ring struct {
-	mu    sync.Mutex
-	lines []string
-	size  int
-	pos   int
-	full  bool
+	mu           sync.Mutex
+	lines        []string
+	size         int
+	pos          int
+	full         bool
+	maxLineBytes int
 	// partial holds an incomplete line (no trailing newline yet)
 	partial bytes.Buffer
 }
@@ -22,8 +27,22 @@ type Ring struct {
 // New creates a ring buffer that stores the last n lines.
 func New(n int) *Ring {
 	return &Ring{
-		lines: make([]string, n),
-		size:  n,
+		lines:        make([]string, n),
+		size:         n,
+		maxLineBytes: DefaultMaxLineBytes,
+	}
+}
+
+// NewWithMaxLineBytes creates a ring buffer with a custom per-line byte limit.
+// If maxBytes is <= 0, DefaultMaxLineBytes is used.
+func NewWithMaxLineBytes(n int, maxBytes int) *Ring {
+	if maxBytes <= 0 {
+		maxBytes = DefaultMaxLineBytes
+	}
+	return &Ring{
+		lines:        make([]string, n),
+		size:         n,
+		maxLineBytes: maxBytes,
 	}
 }
 
@@ -50,6 +69,9 @@ func (r *Ring) Write(p []byte) (int, error) {
 }
 
 func (r *Ring) addLine(line string) {
+	if len(line) > r.maxLineBytes {
+		line = line[:r.maxLineBytes] + "... (truncated)"
+	}
 	r.lines[r.pos] = line
 	r.pos = (r.pos + 1) % r.size
 	if r.pos == 0 {

--- a/internal/logbuf/ring_test.go
+++ b/internal/logbuf/ring_test.go
@@ -81,3 +81,63 @@ func TestRingEmpty(t *testing.T) {
 		t.Errorf("expected empty, got %v", lines)
 	}
 }
+
+func TestRingTruncatesLongLines(t *testing.T) {
+	t.Parallel()
+	r := NewWithMaxLineBytes(5, 10)
+
+	// Write a line longer than the 10-byte limit
+	r.Write([]byte("abcdefghijklmnop\n"))
+
+	lines := r.Lines()
+	if len(lines) != 1 {
+		t.Fatalf("expected 1 line, got %d", len(lines))
+	}
+	expected := "abcdefghij... (truncated)"
+	if lines[0] != expected {
+		t.Errorf("expected %q, got %q", expected, lines[0])
+	}
+}
+
+func TestRingDoesNotTruncateShortLines(t *testing.T) {
+	t.Parallel()
+	r := NewWithMaxLineBytes(5, 100)
+	r.Write([]byte("short line\n"))
+
+	lines := r.Lines()
+	if len(lines) != 1 {
+		t.Fatalf("expected 1 line, got %d", len(lines))
+	}
+	if lines[0] != "short line" {
+		t.Errorf("expected 'short line', got %q", lines[0])
+	}
+}
+
+func TestRingDefaultMaxLineBytes(t *testing.T) {
+	t.Parallel()
+	r := New(5)
+	if r.maxLineBytes != DefaultMaxLineBytes {
+		t.Errorf("expected default max line bytes %d, got %d", DefaultMaxLineBytes, r.maxLineBytes)
+	}
+}
+
+func TestRingTruncatesAtExactLimit(t *testing.T) {
+	t.Parallel()
+	r := NewWithMaxLineBytes(5, 5)
+
+	// Exactly at limit — should not truncate
+	r.Write([]byte("abcde\n"))
+	lines := r.Lines()
+	if lines[0] != "abcde" {
+		t.Errorf("expected 'abcde', got %q", lines[0])
+	}
+
+	// One byte over limit — should truncate
+	r2 := NewWithMaxLineBytes(5, 5)
+	r2.Write([]byte("abcdef\n"))
+	lines2 := r2.Lines()
+	expected := "abcde... (truncated)"
+	if lines2[0] != expected {
+		t.Errorf("expected %q, got %q", expected, lines2[0])
+	}
+}


### PR DESCRIPTION
## Summary

- Truncate log lines exceeding a configurable maximum (default 8KB) in the ring buffer to prevent unbounded memory consumption
- Add `NewWithMaxLineBytes` constructor for custom per-line limits; existing `New()` uses the 8KB default for backward compatibility
- Truncated lines are suffixed with `... (truncated)` for visibility

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./...` passes
- [x] New tests: `TestRingTruncatesLongLines`, `TestRingDoesNotTruncateShortLines`, `TestRingDefaultMaxLineBytes`, `TestRingTruncatesAtExactLimit`

Closes #37