### PR TITLE
fix: kill orphaned process on port before restart

### DIFF
--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -31,24 +31,24 @@ const (
 
 // Daemon is the top-level process supervisor.
 type Daemon struct {
-	specDir      string
-	stateDir     string
-	specSource   string // optional: source spec directory for drift detection
-	secrets      keychain.Store
-	routing      *routing.TraefikGenerator
-	ports        *port.Allocator
-	services     map[string]*ManagedService
-	deps         *depGraph
-	state        *stateFile
-	mu           sync.RWMutex
-	logger       *slog.Logger
-	ctx          context.Context // daemon lifecycle context, set in Start()
-	adopted      []string        // services adopted during crash recovery, pending redeploy
-	redeployWait time.Duration   // delay before redeploying adopted services (default 10s)
-	peers        map[string]*node.Client // remote daemon peers
-	peerStatus   map[string]bool         // peer name -> reachable
-	certRenewal        *CertRenewal        // automatic node cert renewal (nil = disabled)
-	serviceCertRenewal *ServiceCertRenewal // automatic service cert renewal (nil = disabled)
+	specDir            string
+	stateDir           string
+	specSource         string // optional: source spec directory for drift detection
+	secrets            keychain.Store
+	routing            *routing.TraefikGenerator
+	ports              *port.Allocator
+	services           map[string]*ManagedService
+	deps               *depGraph
+	state              *stateFile
+	mu                 sync.RWMutex
+	logger             *slog.Logger
+	ctx                context.Context         // daemon lifecycle context, set in Start()
+	adopted            []string                // services adopted during crash recovery, pending redeploy
+	redeployWait       time.Duration           // delay before redeploying adopted services (default 10s)
+	peers              map[string]*node.Client // remote daemon peers
+	peerStatus         map[string]bool         // peer name -> reachable
+	certRenewal        *CertRenewal            // automatic node cert renewal (nil = disabled)
+	serviceCertRenewal *ServiceCertRenewal     // automatic service cert renewal (nil = disabled)
 }
 
 // NewDaemon creates a new daemon that manages services from the given spec directory.

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -541,18 +541,47 @@ func (d *Daemon) RestartService(name string, timeout time.Duration) error {
 		cascadeTargets = g.cascadeStopTargets(name)
 	}
 
+	// Capture the OS-observed process name before stopping so we can match
+	// exec-replaced processes (whose running name differs from the spec command).
+	// Reading from the live driver while the process is still running is more
+	// reliable than reading from the state file after stop.
+	d.mu.RLock()
+	ms, ok := d.services[name]
+	d.mu.RUnlock()
+	var knownProcessName string
+	if ok {
+		ms.mu.Lock()
+		// drv is nil if the service has never started successfully.
+		if ms.drv != nil {
+			if pid := ms.drv.Info().PID; pid > 0 {
+				knownProcessName, _ = driver.ProcessName(pid)
+			}
+		}
+		ms.mu.Unlock()
+	}
+
 	if err := d.StopService(name, timeout); err != nil {
 		return err
 	}
 
 	// Reset restart counter so the service gets a fresh set of attempts
 	d.mu.RLock()
-	ms, ok := d.services[name]
+	ms, ok = d.services[name]
 	d.mu.RUnlock()
 	if ok {
 		ms.mu.Lock()
 		ms.restartCount = 0
 		ms.mu.Unlock()
+	}
+
+	// Proactively kill any orphaned OS process still holding the service port.
+	// The previously-supervised process may have survived SIGTERM (e.g. adopted
+	// process from crash recovery); if it is still on the port the new start will
+	// fail asynchronously with no recovery path.
+	// ms.spec is safe to read without holding d.mu — it is set once at
+	// construction and never reassigned.
+	if ok {
+		d.killOrphanOnPort(ms.spec, knownProcessName)
 	}
 
 	if err := d.StartService(d.ctx, name); err != nil {
@@ -581,6 +610,74 @@ func (d *Daemon) RestartService(name string, timeout time.Duration) error {
 	}
 
 	return nil
+}
+
+// killOrphanOnPort kills any OS process holding s's port before a restart.
+// Called from RestartService between StopService and StartService to prevent
+// "address already in use" when the previously-supervised process survived.
+// knownProcessName is the OS-reported name captured from the live driver before
+// stop; it is used as a second match tier to handle exec-replaced processes whose
+// running name differs from the spec command (mirrors recoverOrphanedPort).
+// Errors are logged but not returned — the caller proceeds regardless.
+func (d *Daemon) killOrphanOnPort(s *spec.ServiceSpec, knownProcessName string) {
+	port := 0
+	if s.Network != nil {
+		port = s.Network.Port
+	}
+	if port == 0 && s.NeedsDynamicPort() {
+		port = d.ports.Port(s.Service.Name)
+	}
+	if port <= 0 {
+		return
+	}
+
+	holderPID := driver.FindPIDOnPort(port)
+	if holderPID <= 0 {
+		return
+	}
+
+	name := s.Service.Name
+
+	// Guard: never kill the daemon's own process.
+	if holderPID == os.Getpid() {
+		d.logger.Error("port held by aurelia daemon itself, not killing",
+			"service", name, "port", port)
+		return
+	}
+
+	commandMatch := s.Service.Command != "" && driver.VerifyProcess(holderPID, s.Service.Command, 0)
+	nameMatch := knownProcessName != "" && driver.VerifyProcess(holderPID, knownProcessName, 0)
+	if (s.Service.Command != "" || knownProcessName != "") && !commandMatch && !nameMatch {
+		holderName, _ := driver.ProcessName(holderPID)
+		d.logger.Warn("port held by unrelated process during restart, skipping kill",
+			"service", name, "port", port, "holder_pid", holderPID, "holder_name", holderName)
+		return
+	}
+
+	// Kill to free the port for the incoming restart. Unlike recoverOrphanedPort
+	// (which adopts a matching orphan when found during startup), here we have an
+	// explicit restart in progress — adopting the old process would silently
+	// preserve the old instance instead of starting the fresh one the caller
+	// requested.
+	holderName, _ := driver.ProcessName(holderPID)
+	d.logger.Warn("orphaned process holding port before restart, killing",
+		"service", name, "port", port, "orphan_pid", holderPID, "holder_name", holderName)
+
+	orphan, err := driver.NewAdopted(holderPID)
+	if err != nil {
+		// Process disappeared between FindPIDOnPort and now — port is free.
+		d.logger.Info("orphan disappeared before kill", "service", name, "orphan_pid", holderPID)
+		return
+	}
+
+	killCtx, cancel := context.WithTimeout(d.ctx, 10*time.Second)
+	defer cancel()
+	if err := orphan.Stop(killCtx, 10*time.Second); err != nil {
+		d.logger.Error("failed to kill orphan during restart",
+			"service", name, "orphan_pid", holderPID, "error", err)
+	} else {
+		d.logger.Info("killed orphan before restart", "service", name, "killed_pid", holderPID)
+	}
 }
 
 // ServiceStates returns the state of all managed services.

--- a/internal/daemon/daemon_test.go
+++ b/internal/daemon/daemon_test.go
@@ -1541,7 +1541,7 @@ func TestKillOrphanOnPortUnrelatedProcess(t *testing.T) {
 	if err := cmd.Start(); err != nil {
 		t.Fatalf("starting nc: %v", err)
 	}
-	go cmd.Wait() //nolint:errcheck
+	go cmd.Wait()
 	t.Cleanup(func() { cmd.Process.Kill() })
 
 	// Wait until nc is actually listening.
@@ -1601,7 +1601,7 @@ func TestKillOrphanOnPortKnownNameMatch(t *testing.T) {
 	if err := cmd.Start(); err != nil {
 		t.Fatalf("starting nc: %v", err)
 	}
-	go cmd.Wait() //nolint:errcheck
+	go cmd.Wait()
 	t.Cleanup(func() { cmd.Process.Kill() })
 
 	deadline := time.Now().Add(3 * time.Second)
@@ -1665,7 +1665,7 @@ func TestKillOrphanOnPortMatchingProcess(t *testing.T) {
 		t.Fatalf("starting nc: %v", err)
 	}
 	// Reap the child so it doesn't become a zombie — we check port release, not PID death.
-	go cmd.Wait() //nolint:errcheck
+	go cmd.Wait()
 	t.Cleanup(func() { cmd.Process.Kill() })
 
 	// Wait until nc is actually listening (up to 3 seconds).

--- a/internal/daemon/daemon_test.go
+++ b/internal/daemon/daemon_test.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"syscall"
 	"testing"
@@ -1483,5 +1484,226 @@ service:
 	}
 	if state.PID == os.Getpid() {
 		t.Error("should not have adopted the stale PID")
+	}
+}
+
+func TestKillOrphanOnPortFree(t *testing.T) {
+	// When nothing holds the port, killOrphanOnPort should be a no-op.
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	port := ln.Addr().(*net.TCPAddr).Port
+	ln.Close()
+
+	dir := t.TempDir()
+	writeSpec(t, dir, "svc.yaml", fmt.Sprintf(`
+service:
+  name: svc
+  type: native
+  command: "sleep 300"
+
+network:
+  port: %d
+`, port))
+
+	specs, err := spec.LoadDir(dir)
+	if err != nil {
+		t.Fatalf("LoadDir: %v", err)
+	}
+
+	d := NewDaemon(dir)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	d.ctx = ctx
+
+	// Should not panic or error — port is already free.
+	d.killOrphanOnPort(specs[0], "")
+}
+
+func TestKillOrphanOnPortUnrelatedProcess(t *testing.T) {
+	// When the port is held by an external process whose name does NOT match the
+	// spec command or the known process name, killOrphanOnPort must refuse to kill it.
+	if _, err := exec.LookPath("nc"); err != nil {
+		t.Skip("nc not in PATH")
+	}
+
+	// Grab a free port then release it for nc to bind.
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	port := ln.Addr().(*net.TCPAddr).Port
+	ln.Close()
+
+	// Start nc as the port holder — its binary name is "nc", not "sleep".
+	cmd := exec.Command("nc", "-l", "127.0.0.1", strconv.Itoa(port))
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("starting nc: %v", err)
+	}
+	go cmd.Wait() //nolint:errcheck
+	t.Cleanup(func() { cmd.Process.Kill() })
+
+	// Wait until nc is actually listening.
+	deadline := time.Now().Add(3 * time.Second)
+	for driver.FindPIDOnPort(port) == 0 {
+		if time.Now().After(deadline) {
+			t.Fatal("nc did not start listening in time")
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+
+	// The spec command and known process name both say "sleep" — neither matches nc.
+	dir := t.TempDir()
+	writeSpec(t, dir, "svc.yaml", fmt.Sprintf(`
+service:
+  name: svc
+  type: native
+  command: "sleep 300"
+
+network:
+  port: %d
+`, port))
+
+	specs, err := spec.LoadDir(dir)
+	if err != nil {
+		t.Fatalf("LoadDir: %v", err)
+	}
+
+	d := NewDaemon(dir)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	d.ctx = ctx
+
+	d.killOrphanOnPort(specs[0], "sleep")
+
+	// nc must still be alive and holding the port.
+	if driver.FindPIDOnPort(port) == 0 {
+		t.Error("expected port to still be held by the unrelated nc process")
+	}
+}
+
+func TestKillOrphanOnPortKnownNameMatch(t *testing.T) {
+	// When the spec command does NOT match the port holder but the knownProcessName
+	// does (exec-replaced process scenario), killOrphanOnPort should still kill it.
+	if _, err := exec.LookPath("nc"); err != nil {
+		t.Skip("nc not in PATH")
+	}
+
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	port := ln.Addr().(*net.TCPAddr).Port
+	ln.Close()
+
+	cmd := exec.Command("nc", "-l", "127.0.0.1", strconv.Itoa(port))
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("starting nc: %v", err)
+	}
+	go cmd.Wait() //nolint:errcheck
+	t.Cleanup(func() { cmd.Process.Kill() })
+
+	deadline := time.Now().Add(3 * time.Second)
+	for driver.FindPIDOnPort(port) == 0 {
+		if time.Now().After(deadline) {
+			t.Fatal("nc did not start listening in time")
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+
+	// Spec command is "myservice" (doesn't match nc), but the known process name
+	// is "nc" (the OS-observed name from a previous exec-replaced start).
+	dir := t.TempDir()
+	writeSpec(t, dir, "svc.yaml", fmt.Sprintf(`
+service:
+  name: svc
+  type: native
+  command: "myservice"
+
+network:
+  port: %d
+`, port))
+
+	specs, err := spec.LoadDir(dir)
+	if err != nil {
+		t.Fatalf("LoadDir: %v", err)
+	}
+
+	d := NewDaemon(dir)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	d.ctx = ctx
+
+	d.killOrphanOnPort(specs[0], "nc")
+
+	if pid := driver.FindPIDOnPort(port); pid != 0 {
+		t.Errorf("expected port %d to be free after killing exec-replaced orphan, still held by PID %d", port, pid)
+	}
+}
+
+func TestKillOrphanOnPortMatchingProcess(t *testing.T) {
+	// When an orphaned process holds the port and its command matches the spec,
+	// killOrphanOnPort should kill it and release the port.
+	if _, err := exec.LookPath("nc"); err != nil {
+		t.Skip("nc not in PATH")
+	}
+
+	// Grab a free port, then release it so nc can bind.
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	port := ln.Addr().(*net.TCPAddr).Port
+	ln.Close()
+
+	// Start nc listening on the port to simulate an orphaned process.
+	// BSD nc (macOS) syntax: nc -l <host> <port>. GNU nc (Linux) uses
+	// different flags; this test is skipped if nc is not in PATH.
+	cmd := exec.Command("nc", "-l", "127.0.0.1", strconv.Itoa(port))
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("starting nc: %v", err)
+	}
+	// Reap the child so it doesn't become a zombie — we check port release, not PID death.
+	go cmd.Wait() //nolint:errcheck
+	t.Cleanup(func() { cmd.Process.Kill() })
+
+	// Wait until nc is actually listening (up to 3 seconds).
+	deadline := time.Now().Add(3 * time.Second)
+	for driver.FindPIDOnPort(port) == 0 {
+		if time.Now().After(deadline) {
+			t.Fatal("nc did not start listening in time")
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+
+	dir := t.TempDir()
+	writeSpec(t, dir, "svc.yaml", fmt.Sprintf(`
+service:
+  name: svc
+  type: native
+  command: "nc -l 127.0.0.1 %d"
+
+network:
+  port: %d
+`, port, port))
+
+	specs, err := spec.LoadDir(dir)
+	if err != nil {
+		t.Fatalf("LoadDir: %v", err)
+	}
+
+	d := NewDaemon(dir)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	d.ctx = ctx
+
+	d.killOrphanOnPort(specs[0], "nc")
+
+	// After killOrphanOnPort returns the orphan has been signalled (SIGTERM or
+	// SIGKILL). The process releases its socket on exit, so the port should be
+	// free — even if the PID lingers briefly as a zombie.
+	if pid := driver.FindPIDOnPort(port); pid != 0 {
+		t.Errorf("expected port %d to be free after killOrphanOnPort, still held by PID %d", port, pid)
 	}
 }

--- a/internal/driver/adopted.go
+++ b/internal/driver/adopted.go
@@ -92,6 +92,10 @@ func (d *AdoptedDriver) Start(ctx context.Context) error {
 
 func (d *AdoptedDriver) Stop(ctx context.Context, timeout time.Duration) error {
 	d.mu.Lock()
+	// If state is not StateRunning, the process is already gone: either Stop()
+	// was already called, or the monitor goroutine detected exit via kill(pid,0)
+	// and set StateFailed.  In both cases there is nothing to signal — the
+	// underlying PID is dead.
 	if d.state != StateRunning {
 		d.mu.Unlock()
 		return nil

--- a/internal/driver/adopted.go
+++ b/internal/driver/adopted.go
@@ -20,8 +20,8 @@ type AdoptedDriver struct {
 	exitCode  int
 	exitErr   string
 	done      chan struct{}
-	stopCh    chan struct{}    // signals monitor to stop polling
-	monitorWg sync.WaitGroup  // tracks monitor goroutine lifetime
+	stopCh    chan struct{}  // signals monitor to stop polling
+	monitorWg sync.WaitGroup // tracks monitor goroutine lifetime
 }
 
 // NewAdopted creates a driver that monitors an already-running process.


### PR DESCRIPTION
## Summary

- Adds `killOrphanOnPort()` helper called from `RestartService` between `StopService` and `StartService`
- When an adopted process survives SIGTERM it may still hold the port, causing the new start to fail asynchronously with no recovery path — `recoverOrphanedPort` handles this in `Daemon.Start()` but the restart path had no equivalent
- Two-tier matching (spec command + OS-observed process name captured from live driver before stop) handles exec-replaced processes whose running name differs from the spec command
- Skips kill if the port holder doesn't match either tier, guarding against unrelated processes
- Documents why `AdoptedDriver.Stop()`'s state guard is correct (not a bug)

## Test plan

- [x] `go build ./...` compiles cleanly
- [x] `go test ./...` all tests pass
- [x] `TestKillOrphanOnPortFree` — no-op when port is already free
- [x] `TestKillOrphanOnPortUnrelatedProcess` — refuses to kill when neither tier matches
- [x] `TestKillOrphanOnPortKnownNameMatch` — kills via name match tier (exec-replaced process path)
- [x] `TestKillOrphanOnPortMatchingProcess` — kills via command match tier

Note: CI passes cleanly once #62 and #59 are merged first.

Depends on #59
Fixes #57