### PR TITLE
fix: run gofmt across repo to clear formatting drift

### DIFF
--- a/cmd/aurelia/diagnose.go
+++ b/cmd/aurelia/diagnose.go
@@ -9,11 +9,11 @@ import (
 	"strings"
 	"time"
 
+	"github.com/benaskins/aurelia/internal/config"
+	"github.com/benaskins/aurelia/internal/diagnose"
 	talk "github.com/benaskins/axon-talk"
 	"github.com/benaskins/axon-talk/anthropic"
 	"github.com/benaskins/axon-talk/openai"
-	"github.com/benaskins/aurelia/internal/config"
-	"github.com/benaskins/aurelia/internal/diagnose"
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/spf13/cobra"
 )

--- a/internal/api/lamina.go
+++ b/internal/api/lamina.go
@@ -35,10 +35,10 @@ type laminaRequest struct {
 
 // laminaResponse is the JSON response from POST /v1/lamina.
 type laminaResponse struct {
-	ExitCode int              `json:"exit_code"`
-	Output   json.RawMessage  `json:"output,omitempty"`  // parsed JSON if --json output
-	Raw      string           `json:"raw,omitempty"`      // raw text if not valid JSON
-	Error    string           `json:"error,omitempty"`
+	ExitCode int             `json:"exit_code"`
+	Output   json.RawMessage `json:"output,omitempty"` // parsed JSON if --json output
+	Raw      string          `json:"raw,omitempty"`    // raw text if not valid JSON
+	Error    string          `json:"error,omitempty"`
 }
 
 const laminaExecTimeout = 5 * time.Minute

--- a/internal/api/ratelimit.go
+++ b/internal/api/ratelimit.go
@@ -80,4 +80,3 @@ func (rl *rateLimitMiddleware) cleanup() {
 		})
 	}
 }
-

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -47,11 +47,11 @@ type Server struct {
 	nodeName    string // local node name for stamping on service states
 	laminaRoot  string // workspace root for lamina CLI execution
 	configPath  string // path to config file for token updates
-	rateLimiter  *rateLimitMiddleware
-	tokenVendor  *keychain.BaoTokenVendor
-	knownNodes   map[string]bool // valid peer CNs for token vending
-	pkiIssuer    *keychain.BaoPKIIssuer
-	secretCache  *keychain.CachedStore
+	rateLimiter *rateLimitMiddleware
+	tokenVendor *keychain.BaoTokenVendor
+	knownNodes  map[string]bool // valid peer CNs for token vending
+	pkiIssuer   *keychain.BaoPKIIssuer
+	secretCache *keychain.CachedStore
 }
 
 // NewServer creates an API server backed by the given daemon.
@@ -510,8 +510,8 @@ func (s *Server) serviceHealth(w http.ResponseWriter, r *http.Request) {
 	history, _ := s.daemon.ServiceHealthHistory(name)
 
 	type healthResponse struct {
-		Status  string                `json:"status"`
-		History []health.CheckRecord  `json:"history"`
+		Status  string               `json:"status"`
+		History []health.CheckRecord `json:"history"`
 	}
 	writeJSON(w, http.StatusOK, healthResponse{
 		Status:  string(state.Health),

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -14,7 +14,7 @@ import (
 // Node represents a remote aurelia daemon peer.
 type Node struct {
 	Name      string `yaml:"name"`
-	Addr      string `yaml:"addr"`                // e.g. "aurelia.local:9090"
+	Addr      string `yaml:"addr"`                 // e.g. "aurelia.local:9090"
 	Token     string `yaml:"token,omitempty"`      // inline token
 	TokenFile string `yaml:"token_file,omitempty"` // path to token file
 }
@@ -80,9 +80,9 @@ type OpenBaoPeer struct {
 
 // Diagnose configures the LLM-powered diagnostic engine.
 type Diagnose struct {
-	Provider     string `yaml:"provider"`        // LLM provider: "anthropic", "openai"
-	Model        string `yaml:"model"`           // model name, e.g. "claude-sonnet-4-20250514"
-	APIKeySecret string `yaml:"api_key_secret"`  // secret name for the API key (resolved via aurelia secret)
+	Provider     string `yaml:"provider"`           // LLM provider: "anthropic", "openai"
+	Model        string `yaml:"model"`              // model name, e.g. "claude-sonnet-4-20250514"
+	APIKeySecret string `yaml:"api_key_secret"`     // secret name for the API key (resolved via aurelia secret)
 	BaseURL      string `yaml:"base_url,omitempty"` // base URL for openai-compatible providers
 }
 
@@ -97,12 +97,12 @@ type ServiceCertConfig struct {
 
 // Config holds persistent daemon configuration loaded from ~/.aurelia/config.yaml.
 type Config struct {
-	RoutingOutput string    `yaml:"routing_output"`
-	APIAddr       string    `yaml:"api_addr"`
-	NodeName      string    `yaml:"node_name,omitempty"`
-	Nodes         []Node    `yaml:"nodes,omitempty"`
-	LaminaRoot    string    `yaml:"lamina_root,omitempty"`
-	SpecSource    string    `yaml:"spec_source,omitempty"` // source spec directory for drift detection
+	RoutingOutput string              `yaml:"routing_output"`
+	APIAddr       string              `yaml:"api_addr"`
+	NodeName      string              `yaml:"node_name,omitempty"`
+	Nodes         []Node              `yaml:"nodes,omitempty"`
+	LaminaRoot    string              `yaml:"lamina_root,omitempty"`
+	SpecSource    string              `yaml:"spec_source,omitempty"` // source spec directory for drift detection
 	TLS           *TLS                `yaml:"tls,omitempty"`
 	OpenBao       *OpenBao            `yaml:"openbao,omitempty"`
 	OpenBaoPeer   *OpenBaoPeer        `yaml:"openbao_peer,omitempty"`

--- a/internal/daemon/cert_renewal.go
+++ b/internal/daemon/cert_renewal.go
@@ -17,13 +17,13 @@ import (
 // For peer nodes, it calls the PKI renew endpoint on adyton.
 // For adyton itself, it issues directly via the PKI secrets engine.
 type CertRenewal struct {
-	certFile  string // path to node cert PEM
-	keyFile   string // path to node key PEM
-	caFile    string // path to CA chain PEM
-	nodeName  string // local node name (used as CN)
-	renewAt   time.Time
-	mu        sync.Mutex
-	logger    *slog.Logger
+	certFile string // path to node cert PEM
+	keyFile  string // path to node key PEM
+	caFile   string // path to CA chain PEM
+	nodeName string // local node name (used as CN)
+	renewAt  time.Time
+	mu       sync.Mutex
+	logger   *slog.Logger
 
 	// One of these is set depending on whether this is adyton or a peer.
 	pkiIssuer *keychain.BaoPKIIssuer // non-nil on adyton (self-renewal)

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -31,24 +31,24 @@ const (
 
 // Daemon is the top-level process supervisor.
 type Daemon struct {
-	specDir      string
-	stateDir     string
-	specSource   string // optional: source spec directory for drift detection
-	secrets      keychain.Store
-	routing      *routing.TraefikGenerator
-	ports        *port.Allocator
-	services     map[string]*ManagedService
-	deps         *depGraph
-	state        *stateFile
-	mu           sync.RWMutex
-	logger       *slog.Logger
-	ctx          context.Context // daemon lifecycle context, set in Start()
-	adopted      []string        // services adopted during crash recovery, pending redeploy
-	redeployWait time.Duration   // delay before redeploying adopted services (default 10s)
-	peers        map[string]*node.Client // remote daemon peers
-	peerStatus   map[string]bool         // peer name -> reachable
-	certRenewal        *CertRenewal        // automatic node cert renewal (nil = disabled)
-	serviceCertRenewal *ServiceCertRenewal // automatic service cert renewal (nil = disabled)
+	specDir            string
+	stateDir           string
+	specSource         string // optional: source spec directory for drift detection
+	secrets            keychain.Store
+	routing            *routing.TraefikGenerator
+	ports              *port.Allocator
+	services           map[string]*ManagedService
+	deps               *depGraph
+	state              *stateFile
+	mu                 sync.RWMutex
+	logger             *slog.Logger
+	ctx                context.Context         // daemon lifecycle context, set in Start()
+	adopted            []string                // services adopted during crash recovery, pending redeploy
+	redeployWait       time.Duration           // delay before redeploying adopted services (default 10s)
+	peers              map[string]*node.Client // remote daemon peers
+	peerStatus         map[string]bool         // peer name -> reachable
+	certRenewal        *CertRenewal            // automatic node cert renewal (nil = disabled)
+	serviceCertRenewal *ServiceCertRenewal     // automatic service cert renewal (nil = disabled)
 }
 
 // NewDaemon creates a new daemon that manages services from the given spec directory.

--- a/internal/daemon/service.go
+++ b/internal/daemon/service.go
@@ -372,7 +372,7 @@ func (ms *ManagedService) HealthHistory() []health.CheckRecord {
 type supervisionPhase int
 
 const (
-	phaseStarting    supervisionPhase = iota // Create driver and start the process
+	phaseStarting   supervisionPhase = iota // Create driver and start the process
 	phaseRunning                            // Wait for process exit or health failure
 	phaseEvaluating                         // Decide whether to restart based on exit code and policy
 	phaseRestarting                         // Wait for restart delay, then loop back to starting

--- a/internal/daemon/service_cert_renewal.go
+++ b/internal/daemon/service_cert_renewal.go
@@ -25,10 +25,10 @@ type ServiceCert struct {
 // ServiceCertRenewal manages automatic renewal of service TLS certificates
 // (server and client certs) via the CA peer node.
 type ServiceCertRenewal struct {
-	certs   []ServiceCert
-	adyton  *node.Client
-	mu      sync.Mutex
-	logger  *slog.Logger
+	certs  []ServiceCert
+	adyton *node.Client
+	mu     sync.Mutex
+	logger *slog.Logger
 
 	// postRenew is called after any cert is renewed (e.g. to restart traefik).
 	postRenew func()

--- a/internal/daemon/state.go
+++ b/internal/daemon/state.go
@@ -22,10 +22,10 @@ type ServiceRecord struct {
 	PID         int    `json:"pid,omitempty"`
 	Type        string `json:"type"`
 	Port        int    `json:"port,omitempty"`
-	StartedAt   int64  `json:"started_at,omitempty"`    // Unix timestamp
-	Command     string `json:"command,omitempty"`        // process command for PID reuse detection
-	StartTime   int64  `json:"start_time,omitempty"`     // OS-reported process start time for PID reuse detection
-	ProcessName string `json:"process_name,omitempty"`   // OS-reported executable name (may differ from command after exec)
+	StartedAt   int64  `json:"started_at,omitempty"`   // Unix timestamp
+	Command     string `json:"command,omitempty"`      // process command for PID reuse detection
+	StartTime   int64  `json:"start_time,omitempty"`   // OS-reported process start time for PID reuse detection
+	ProcessName string `json:"process_name,omitempty"` // OS-reported executable name (may differ from command after exec)
 }
 
 // newServiceRecord creates a ServiceRecord with the common fields populated.

--- a/internal/diagnose/tui.go
+++ b/internal/diagnose/tui.go
@@ -359,7 +359,7 @@ func (m *TUIModel) refreshViewport() {
 			sb.WriteString("\n\n")
 		case "agent":
 			sb.WriteString(agentLabelStyle.Render("aurelia") + " ")
-			sb.WriteString(agentStyle.Width(contentWidth-9).Render(e.content))
+			sb.WriteString(agentStyle.Width(contentWidth - 9).Render(e.content))
 			sb.WriteString("\n\n")
 		case "tool":
 			sb.WriteString(toolStyle.Render(e.content))
@@ -373,7 +373,7 @@ func (m *TUIModel) refreshViewport() {
 	if m.streaming != "" || m.toolRunning {
 		sb.WriteString(agentLabelStyle.Render("aurelia") + " ")
 		if m.streaming != "" {
-			sb.WriteString(agentStyle.Width(contentWidth-9).Render(m.streaming))
+			sb.WriteString(agentStyle.Width(contentWidth - 9).Render(m.streaming))
 		}
 		if m.toolRunning {
 			sb.WriteString(m.spinner.View())

--- a/internal/driver/adopted.go
+++ b/internal/driver/adopted.go
@@ -20,8 +20,8 @@ type AdoptedDriver struct {
 	exitCode  int
 	exitErr   string
 	done      chan struct{}
-	stopCh    chan struct{}    // signals monitor to stop polling
-	monitorWg sync.WaitGroup  // tracks monitor goroutine lifetime
+	stopCh    chan struct{}  // signals monitor to stop polling
+	monitorWg sync.WaitGroup // tracks monitor goroutine lifetime
 }
 
 // NewAdopted creates a driver that monitors an already-running process.

--- a/internal/multinode/cluster.go
+++ b/internal/multinode/cluster.go
@@ -475,4 +475,3 @@ func (c *Cluster) waitForPeerDiscovery(t *testing.T, timeout time.Duration) {
 	}
 	t.Fatalf("peer discovery did not complete within %s", timeout)
 }
-

--- a/internal/node/client.go
+++ b/internal/node/client.go
@@ -32,7 +32,7 @@ func peerTransport(tlsConfig *tls.Config) *http.Transport {
 	}
 	t := &http.Transport{
 		DialContext:         dialer.DialContext,
-		IdleConnTimeout:    15 * time.Second,
+		IdleConnTimeout:     15 * time.Second,
 		MaxIdleConnsPerHost: 1,
 		TLSHandshakeTimeout: 5 * time.Second,
 	}
@@ -217,10 +217,10 @@ func (c *Client) Inspect(name string) (json.RawMessage, error) {
 
 // LaminaResponse is the response from a remote lamina command execution.
 type LaminaResponse struct {
-	ExitCode int              `json:"exit_code"`
-	Output   json.RawMessage  `json:"output,omitempty"`
-	Raw      string           `json:"raw,omitempty"`
-	Error    string           `json:"error,omitempty"`
+	ExitCode int             `json:"exit_code"`
+	Output   json.RawMessage `json:"output,omitempty"`
+	Raw      string          `json:"raw,omitempty"`
+	Error    string          `json:"error,omitempty"`
 }
 
 // Lamina executes a lamina CLI command on the remote daemon.

--- a/internal/spec/spec.go
+++ b/internal/spec/spec.go
@@ -41,7 +41,7 @@ type Service struct {
 	Image       string  `yaml:"image,omitempty"`        // container only
 	NetworkMode string  `yaml:"network_mode,omitempty"` // container only, default "host"
 	Privileged  bool    `yaml:"privileged,omitempty"`   // container only
-	Source      *Source `yaml:"source,omitempty"`        // optional: where to fetch and build
+	Source      *Source `yaml:"source,omitempty"`       // optional: where to fetch and build
 }
 
 // Source describes where a service's source code lives and how to build it.


### PR DESCRIPTION
## Summary

- Runs `gofmt -w .` across the repository to fix accumulated struct field alignment drift
- No logic changes — whitespace, alignment, and import ordering only

## Test plan

- [x] `go build ./...` compiles cleanly
- [x] `go test ./...` all tests pass
- [x] `gofmt -l .` reports no files

Note: CI passes cleanly once #62 is merged first.

Depends on #62
Fixes #60