### PR TITLE
fix: poll for running state in TestDaemonRecoverOrphanByCommandMatch

### DIFF
--- a/internal/daemon/daemon_test.go
+++ b/internal/daemon/daemon_test.go
@@ -1226,6 +1226,7 @@ service:
 	if err := orphanCmd.Start(); err != nil {
 		t.Fatalf("starting orphan process: %v", err)
 	}
+	orphanPID := orphanCmd.Process.Pid
 	go orphanCmd.Wait()
 	t.Cleanup(func() { orphanCmd.Process.Kill() })
 
@@ -1266,13 +1267,19 @@ service:
 		t.Fatal("expected service to be in adopted list (found by command match)")
 	}
 
-	// The adopted PID should be the orphan, not the decoy
+	// The adopted PID should be the orphan, not the decoy. Check immediately
+	// after Start — before the 1ms redeploy goroutine is likely to have fired.
 	state, err := d.ServiceState("sleeper")
 	if err != nil {
 		t.Fatalf("ServiceState: %v", err)
 	}
 	if state.PID == decoyPID {
 		t.Error("should not have adopted the decoy PID")
+	}
+	if state.PID != orphanPID {
+		// Another sleep 300 process on the system may match first — log for
+		// diagnostics but don't hard-fail; the decoy check above is the real guard.
+		t.Logf("adopted PID %d, orphan was %d (may have matched a different sleep 300 or already redeployed)", state.PID, orphanPID)
 	}
 
 	// redeployWait is 1ms, so the redeploy goroutine may have already stopped

--- a/internal/daemon/daemon_test.go
+++ b/internal/daemon/daemon_test.go
@@ -1226,7 +1226,6 @@ service:
 	if err := orphanCmd.Start(); err != nil {
 		t.Fatalf("starting orphan process: %v", err)
 	}
-	orphanPID := orphanCmd.Process.Pid
 	go orphanCmd.Wait()
 	t.Cleanup(func() { orphanCmd.Process.Kill() })
 
@@ -1267,19 +1266,28 @@ service:
 		t.Fatal("expected service to be in adopted list (found by command match)")
 	}
 
+	// The adopted PID should be the orphan, not the decoy
 	state, err := d.ServiceState("sleeper")
 	if err != nil {
 		t.Fatalf("ServiceState: %v", err)
 	}
-
-	// The adopted PID should be the orphan, not the decoy
 	if state.PID == decoyPID {
 		t.Error("should not have adopted the decoy PID")
 	}
-	if state.PID != orphanPID {
-		// It might have been redeployed already, which is fine — just verify
-		// the service is running
-		t.Logf("PID is %d (orphan was %d), may have already been redeployed", state.PID, orphanPID)
+
+	// redeployWait is 1ms, so the redeploy goroutine may have already stopped
+	// and restarted the service by the time we check. Poll until running rather
+	// than asserting immediately against a transitional state.
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		state, err = d.ServiceState("sleeper")
+		if err != nil {
+			t.Fatalf("ServiceState: %v", err)
+		}
+		if state.State == "running" {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
 	}
 	if state.State != "running" {
 		t.Errorf("expected running, got %v", state.State)


### PR DESCRIPTION
## Summary

- `redeployWait` is set to 1ms in this test, so the redeploy goroutine can stop and restart the service before the `ServiceState` assertion runs
- Replace the immediate state check with a poll loop (2s deadline, 10ms interval), consistent with the polling pattern used elsewhere in this file
- Restore `orphanPID` as a diagnostic log — it cannot be a hard assertion because `sleep 300` is not unique enough to guarantee the test orphan is the first match on any given machine; the `decoyPID` check is the real correctness guard (see #63)

## Test plan

- [x] `go build ./...` compiles cleanly
- [x] `go test ./...` all tests pass
- [x] `TestDaemonRecoverOrphanByCommandMatch` passes 10/10 locally with `-count=10`

Fixes #61