### PR TITLE
feat(daemon): rotate daemon.log instead of relying on launchd capture

### DIFF
--- a/cmd/aurelia/daemon.go
+++ b/cmd/aurelia/daemon.go
@@ -42,6 +42,18 @@ func init() {
 }
 
 func runDaemon(cmd *cobra.Command, args []string) error {
+	// Route daemon logs to a size-rotating file. launchd's StandardErrorPath
+	// capture holds the fd open and never rotates, so daemon.log grew unbounded
+	// (~300MB). slog now writes the rotating file directly; launchd captures only
+	// early stdout/stderr and panics to daemon.boot.log (see install.go plist).
+	if home, err := os.UserHomeDir(); err == nil {
+		logPath := filepath.Join(home, ".aurelia", "daemon.log")
+		if mkErr := os.MkdirAll(filepath.Dir(logPath), 0o700); mkErr == nil {
+			lw := LogWriter(logPath)
+			slog.SetDefault(slog.New(slog.NewTextHandler(lw, &slog.HandlerOptions{Level: slog.LevelInfo})))
+		}
+	}
+
 	// Safety check: warn/block manual starts when a LaunchAgent is installed
 	if warning, err := launchdCheck(daemonForce); err != nil {
 		return err

--- a/cmd/aurelia/install.go
+++ b/cmd/aurelia/install.go
@@ -37,6 +37,10 @@ var installCmd = &cobra.Command{
 		plistDir := filepath.Join(home, "Library", "LaunchAgents")
 		plistPath := filepath.Join(plistDir, launchAgentLabel+".plist")
 		logPath := filepath.Join(home, ".aurelia", "daemon.log")
+		// launchd captures only early stdout/stderr and panics here; the daemon's
+		// slog output goes to the rotating daemon.log (internal/daemon.LogWriter).
+		// Pointing launchd at daemon.log too would double-write and defeat rotation.
+		bootLogPath := filepath.Join(home, ".aurelia", "daemon.boot.log")
 
 		if err := os.MkdirAll(plistDir, 0755); err != nil {
 			return fmt.Errorf("creating LaunchAgents dir: %w", err)
@@ -74,7 +78,7 @@ var installCmd = &cobra.Command{
     <string>%s</string>
 </dict>
 </plist>
-`, launchAgentLabel, html.EscapeString(binary), envSection, html.EscapeString(logPath), html.EscapeString(logPath))
+`, launchAgentLabel, html.EscapeString(binary), envSection, html.EscapeString(bootLogPath), html.EscapeString(bootLogPath))
 
 		if err := os.WriteFile(plistPath, []byte(plist), 0644); err != nil {
 			return fmt.Errorf("writing plist: %w", err)

--- a/cmd/aurelia/logging.go
+++ b/cmd/aurelia/logging.go
@@ -1,0 +1,19 @@
+package main
+
+import "gopkg.in/natefinch/lumberjack.v2"
+
+// LogWriter returns a size-rotating writer for the daemon log file.
+//
+// The daemon's slog output is written here instead of relying on launchd's
+// StandardErrorPath capture, which holds the file descriptor open and never
+// rotates — daemon.log grew to ~300MB. lumberjack rotates by size and keeps a
+// bounded number of compressed backups.
+func LogWriter(path string) *lumberjack.Logger {
+	return &lumberjack.Logger{
+		Filename:   path,
+		MaxSize:    50, // megabytes before rotation
+		MaxBackups: 5,  // rotated files to retain
+		MaxAge:     30, // days to retain
+		Compress:   true,
+	}
+}

--- a/cmd/aurelia/logging_test.go
+++ b/cmd/aurelia/logging_test.go
@@ -1,0 +1,37 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestLogWriter_WritesToFile(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "daemon.log")
+	w := LogWriter(path)
+	t.Cleanup(func() { _ = w.Close() })
+
+	if _, err := w.Write([]byte("hello aurelia\n")); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read log file: %v", err)
+	}
+	if !strings.Contains(string(data), "hello aurelia") {
+		t.Fatalf("log file missing written content, got %q", data)
+	}
+}
+
+func TestLogWriter_RetainsBoundedBackups(t *testing.T) {
+	w := LogWriter(filepath.Join(t.TempDir(), "daemon.log"))
+	t.Cleanup(func() { _ = w.Close() })
+
+	// Left at zero, lumberjack keeps every rotated file forever — the unbounded
+	// growth this change exists to prevent.
+	if w.MaxBackups <= 0 {
+		t.Errorf("MaxBackups must bound retained files, got %d", w.MaxBackups)
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -17,6 +17,7 @@ require (
 	golang.org/x/sys v0.41.0
 	golang.org/x/term v0.40.0
 	golang.org/x/time v0.15.0
+	gopkg.in/natefinch/lumberjack.v2 v2.2.1
 	gopkg.in/yaml.v3 v3.0.1
 )
 

--- a/go.sum
+++ b/go.sum
@@ -314,6 +314,8 @@ google.golang.org/protobuf v1.36.11/go.mod h1:HTf+CrKn2C3g5S8VImy6tdcUvCska2kB7j
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c h1:Hei/4ADfdWqJk1ZMxUNpqntNwaWcugrBjAiHlqqRiVk=
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c/go.mod h1:JHkPIbrfpd72SG/EVd6muEfDQjcINNoR0C8j2r3qZ4Q=
+gopkg.in/natefinch/lumberjack.v2 v2.2.1 h1:bBRl1b0OH9s/DuPhuXpNl+VtCaJXFZ5/uEFST95x9zc=
+gopkg.in/natefinch/lumberjack.v2 v2.2.1/go.mod h1:YD8tP3GAjkrDg1eZH7EGmyESg/lsYskCTPBJVb9jqSc=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=


### PR DESCRIPTION
## Problem
The daemon logs via slog's default handler to stderr, which launchd captures to `~/.aurelia/daemon.log` via `StandardErrorPath`. launchd holds that fd open for the life of the process and never rotates it, so `daemon.log` grows unbounded — ~300MB observed on two hosts. (Supervised-service output goes to the in-memory ring buffer in `native.go`, not this file, so `daemon.log` is purely the daemon's own logging.)

## Change
- `runDaemon` points slog at a size-rotating writer (`LogWriter` in `cmd/aurelia`): lumberjack, 50MB × 5 compressed backups, 30 days.
- The install plist's `StandardOutPath`/`StandardErrorPath` are repointed to `daemon.boot.log`, so launchd captures only early stdout/stderr and panics. Pointing it at `daemon.log` too would double-write and defeat rotation.
- If `UserHomeDir` fails, the default stderr handler is kept (launchd catches it in the boot log) — logging never silently disappears.

Log format/level are unchanged (text handler, Info), so existing log consumers see the same output, just in a rotating file.

## Migration
Existing installs pick this up after upgrading the binary and re-running `aurelia install` (regenerates the plist) + restarting the daemon.

## Tests
- `TestLogWriter_WritesToFile` — output lands in the configured file.
- `TestLogWriter_RetainsBoundedBackups` — guards the actual bug (`MaxBackups` unset ⇒ lumberjack keeps every rotated file forever).

New dependency: `gopkg.in/natefinch/lumberjack.v2` (standard, single-purpose log rotation).