### PR TITLE
fix(driver): adopt running services by start time, not brittle name match

### DIFF
--- a/internal/driver/adopted.go
+++ b/internal/driver/adopted.go
@@ -180,19 +180,22 @@ func VerifyProcess(pid int, expectedCommand string, expectedStartTime int64) boo
 		return true // no identity recorded, best effort
 	}
 
-	// Check start time first — it's the strongest signal against PID reuse.
+	// Start time + PID uniquely identify a process: PID reuse with an identical
+	// start time is not realistically possible. So a matching start time is
+	// authoritative — trust it and skip the process-name check, which is brittle
+	// for wrapper/exec'd processes (P_comm differs from the command) and long
+	// binary names (P_comm truncates at 16 chars). The name check below is only a
+	// best-effort fallback for when no start time was recorded.
 	if expectedStartTime != 0 {
 		actual, err := processStartTime(pid)
 		if err != nil {
 			return false
 		}
-		if actual != expectedStartTime {
-			return false
-		}
+		return actual == expectedStartTime
 	}
 
 	if expectedCommand == "" {
-		return true // start time matched, no command to check
+		return true
 	}
 
 	actual, err := processName(pid)

--- a/internal/driver/adopted.go
+++ b/internal/driver/adopted.go
@@ -219,6 +219,14 @@ func namesMatch(actual, expected string) bool {
 		return true
 	}
 
+	// macOS kern.proc P_comm caps process names at 16 chars (MAXCOMLEN), so a
+	// longer binary name is reported truncated. If the (truncated) actual name is
+	// a prefix of the expected name, treat it as a match — otherwise a service
+	// whose binary name exceeds 16 chars is wrongly seen as an orphan.
+	if len(actual) >= 15 && strings.HasPrefix(strings.ToLower(expected), strings.ToLower(actual)) {
+		return true
+	}
+
 	// Strip version suffixes for comparison: python3.12 → python, ruby3.2 → ruby
 	return strings.EqualFold(stripVersion(actual), stripVersion(expected))
 }

--- a/internal/driver/namesmatch_test.go
+++ b/internal/driver/namesmatch_test.go
@@ -1,0 +1,16 @@
+package driver
+
+import "testing"
+
+func TestNamesMatchTruncatedComm(t *testing.T) {
+	// macOS kern.proc P_comm caps process names at 16 chars (MAXCOMLEN), so a
+	// longer binary name is reported truncated. The truncated name must still
+	// match the full recorded command, or VerifyProcess wrongly treats a live
+	// service as an orphan (observed wedging the daemon on "werkhaus-dashboard").
+	actual := "werkhaus-dashboa"     // 16 chars, as reported by P_comm
+	expected := "werkhaus-dashboard" // 18 chars, full binary name
+
+	if !namesMatch(actual, expected) {
+		t.Errorf("namesMatch(%q, %q) = false, want true (P_comm truncates to 16 chars)", actual, expected)
+	}
+}

--- a/internal/driver/verifyprocess_starttime_test.go
+++ b/internal/driver/verifyprocess_starttime_test.go
@@ -1,0 +1,29 @@
+package driver
+
+import (
+	"os/exec"
+	"testing"
+)
+
+func TestVerifyProcessStartTimeOverridesNameMismatch(t *testing.T) {
+	// Start time + PID uniquely identify a process, so a matching start time must
+	// verify even when the live process name differs from the recorded command —
+	// which is the norm for wrapper/exec'd or long (>16 char) binary names.
+	cmd := exec.Command("sleep", "30")
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("start sleep: %v", err)
+	}
+	t.Cleanup(func() { _ = cmd.Process.Kill() })
+
+	pid := cmd.Process.Pid
+	startTime, err := processStartTime(pid)
+	if err != nil {
+		t.Fatalf("processStartTime: %v", err)
+	}
+
+	// Recorded command's basename ("start-sleep.sh") does not match the live
+	// process name ("sleep"), but the start time matches.
+	if !VerifyProcess(pid, "/opt/wrappers/start-sleep.sh", startTime) {
+		t.Error("VerifyProcess = false; want true (matching start time is authoritative)")
+	}
+}


### PR DESCRIPTION
## Problem
On daemon restart, `VerifyProcess` confirmed an adopted PID by checking start time **and then** the process name (`P_comm` vs the recorded command basename). The name check fails for several normal cases, so the daemon treated a live service as an orphan and churned kill/restart — wedging startup before the API socket bound:

- **Wrapper/exec'd services** — e.g. ollama launched via a `start-ollama.sh` that `exec`s ollama: `P_comm` is `ollama`, recorded basename is `start-ollama.sh`.
- **Long binary names** — `P_comm` truncates at 16 chars (`MAXCOMLEN`), so `werkhaus-dashboard` (18) and `mac-memory-exporter` (19) never match in full.
- **CLI shims** — `vscode-tunnel`'s `code` execs to `env`, so `P_comm` is `env`.

## Fix (2 commits)
1. **`treat matching start time as authoritative`** (primary) — start time + PID uniquely identify a process; PID reuse with an identical start time isn't realistically possible. So a start-time match returns `true` without the name check. The name check remains a fallback for when no start time was recorded.
2. **`match truncated P_comm names`** (hardening) — in that no-start-time fallback, `namesMatch` now treats a truncated `actual` (≥15 chars) as a match when it's a prefix of the expected name.

## Tests
- `TestVerifyProcessStartTimeOverridesNameMismatch` — real subprocess; start time matches, recorded command name doesn't → verifies.
- `TestNamesMatchTruncatedComm` — `werkhaus-dashboa` (16, truncated) matches `werkhaus-dashboard`.
- Full `internal/driver` suite passes (existing `VerifyProcess` tests unchanged).

Observed live: with this, a daemon restart cleanly adopts ollama / werkhaus-dashboard / mac-memory-exporter / vscode-tunnel (0 restarts) instead of wedging.